### PR TITLE
feat(lock): add ErrEntityLocked to distinguish resource already locked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8.0
         env:
           MYSQL_DATABASE: my_db
           MYSQL_ROOT_PASSWORD: 123456


### PR DESCRIPTION
engine对业务侧需要明确区分是“没有抢到锁”还是“拿锁过程中的存储或网络这类故障性错误”，所以增加了ErrEntityLocked这一错误类型。
但engine和各`ILock`实现之间的交互有两种处理方式：
1. 定义特定的error来区分“没有抢到锁”，即下方提交代码中所示，复用ErrEntityLocked
2. `ILock.Lock`的返回值keyLock为nil来表示“没有抢到锁”，好处是各ILock不用依赖dddfirework定义的错误