### PR TITLE
fix(lock): amend lockerID of UnLock when rewrite exist lock db record

### DIFF
--- a/lock/db/sql_test.go
+++ b/lock/db/sql_test.go
@@ -35,10 +35,13 @@ func TestLock(t *testing.T) {
 	assert.NoError(t, err)
 	r := l.(*ResourceLock)
 	assert.True(t, len(r.LockerID) > 0)
+
 	// 测试lock 过期场景
 	time.Sleep(1 * time.Second)
+	previousID := r.LockerID
 	l, err = lock.Lock(context.Background(), "abc")
 	assert.NoError(t, err)
+	assert.NotEqual(t, previousID, l.(*ResourceLock).LockerID)
 	err = lock.UnLock(context.Background(), l)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
当`resource_lock`表中记录存在时抢到锁时，需要更新锁对象的`LockerID`再返回，以免最终出现无效锁释放