### PR TITLE
feat: add service_event when insert event

### DIFF
--- a/eventbus/mysql/eventbus.go
+++ b/eventbus/mysql/eventbus.go
@@ -394,6 +394,11 @@ func (e *EventBus) getScanEvents(scanStartEventID int64) ([]*EventTuple, error) 
 		}
 		return nil, nil
 	}
+	if earliestRunnableServiceEvent.ID > 0 {
+		if eventOffset < earliestRunnableServiceEvent.ID {
+			eventOffset = earliestRunnableServiceEvent.EventID
+		}
+	}
 	//// 每次只扫描 event.id=[eventOffset,eventBound) 区间内的event，防止未消费event 过多时导致的慢sql，
 	//eventBound := eventOffset + int64(e.opt.LimitPerRun)
 	////eventBound是在eventOffset 超过重试次数之前，最大可以处理到的event

--- a/eventbus/mysql/po.go
+++ b/eventbus/mysql/po.go
@@ -155,6 +155,7 @@ CREATE TABLE `ddd_domain_service_event` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_service_event_id` (`service`,`event_id`),
   KEY `idx_service_status_next_time` (`service`,`status`,`next_time`),
+  KEY `idx_service_status_event_id` (`service`,`status`,`event_id`),
   KEY `idx_ddd_domain_service_event_event_created_at` (`event_created_at`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 */
@@ -162,14 +163,14 @@ CREATE TABLE `ddd_domain_service_event` (
 // ServiceEventPO 记录service对event的处理情况
 type ServiceEventPO struct {
 	ID             int64              `gorm:"primaryKey;autoIncrement"`
-	Service        string             `gorm:"type:varchar(30);column:service;uniqueIndex:idx_service_event_id;index:idx_service_status_next_time;"`
-	EventID        int64              `gorm:"column:event_id;uniqueIndex:idx_service_event_id;not null"`
-	RetryCount     int                `gorm:"type:int(11);column:retry_count"`                                                    // 重试次数
-	Status         ServiceEventStatus `gorm:"type:tinyint;column:status;index:idx_service_status_next_time;"`                     // service event状态
-	FailedMessage  string             `gorm:"type:text;column:failed_message"`                                                    // 失败详情
-	EventCreatedAt time.Time          `gorm:"type:datetime(3);index;not null"`                                                    // 事件的创建时间
-	NextTime       time.Time          `gorm:"type:datetime(3);index:idx_service_status_next_time;not null"`                       // 事件可以运行的事件
-	RunAt          time.Time          `gorm:"type:datetime(3);zeroValue:1970-01-01 00:00:01;default:'1970-01-01 00:00:01+00:00'"` // 事件真实运行时间，单纯记录下
+	Service        string             `gorm:"type:varchar(30);column:service;uniqueIndex:idx_service_event_id;index:idx_service_status_event_id;index:idx_service_status_next_time;"`
+	EventID        int64              `gorm:"column:event_id;uniqueIndex:idx_service_event_id;index:idx_service_status_event_id;not null"`
+	RetryCount     int                `gorm:"type:int(11);column:retry_count"`                                                                  // 重试次数
+	Status         ServiceEventStatus `gorm:"type:tinyint;column:status;index:idx_service_status_event_id;index:idx_service_status_next_time;"` // service event状态
+	FailedMessage  string             `gorm:"type:text;column:failed_message"`                                                                  // 失败详情
+	EventCreatedAt time.Time          `gorm:"type:datetime(3);index;not null"`                                                                  // 事件的创建时间
+	NextTime       time.Time          `gorm:"type:datetime(3);index:idx_service_status_next_time;not null"`                                     // 事件可以运行的事件
+	RunAt          time.Time          `gorm:"type:datetime(3);zeroValue:1970-01-01 00:00:01;default:'1970-01-01 00:00:01+00:00'"`               // 事件真实运行时间，单纯记录下
 }
 
 func (o *ServiceEventPO) TableName() string {

--- a/lock/db/sql_test.go
+++ b/lock/db/sql_test.go
@@ -76,10 +76,10 @@ func TestRun(t *testing.T) {
 	go func() {
 		err = lock.Run(context.Background(), "abc", func(ctx context.Context) {
 			defer wg.Done()
-			time.Sleep(10 * time.Second)
+			time.Sleep(2 * time.Second)
 		})
 	}()
-	time.Sleep(2 * time.Second)
+	time.Sleep(1 * time.Second)
 	// 会加锁失败
 	_, err = lock.Lock(context.Background(), "abc")
 	fmt.Println(err)


### PR DESCRIPTION
1. 新增event时同步新增 service_event。之前是消费event时才新增service_event, 导致消费时必须进行join，进而导致慢查询。
2.  通过扫描event 时限定event.id 在`[eventOffset,eventBound]` 访问，控制每次处理批量大小， 来避免可能出现的慢查询。